### PR TITLE
Underline Text decoration in HW view  confusing

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -298,7 +298,6 @@ tr.odd{
 }
 
 .row_selected{
-    /* text-decoration: underline; This decoration is giving confusing underlines in HW view*/
     color:white;
 }
 

--- a/custom.css
+++ b/custom.css
@@ -298,7 +298,7 @@ tr.odd{
 }
 
 .row_selected{
-    text-decoration: underline;
+    /* text-decoration: underline; This decoration is giving confusing underlines in HW view*/
     color:white;
 }
 


### PR DESCRIPTION
This change will remove the underlines which is show in selected rows in the HW view. This underline decoration is confusing and not required. Therefor suggesting to remove,