### PR TITLE
Text in modal box not visible

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -67,7 +67,12 @@ body:not(.login) #holder .container-fluid{
 /* hacking around all the parts that don't follow span convention*/
 div.ui-popup{box-shadow: 5px 5px 5px rgba(0,0,0,.5)}
 
+.modal-title, .bootbox-body {
+        color: #FFF;
+}
+
 div.ui-popup,
+.modal,
 #protectiontable, 
 #loghistory table, 
 #notifications>table, 


### PR DESCRIPTION
The text in the modal box which shows progress/result is not visible. When the button "Has Node Failed" in the HW overview is clicked the text showing the progress and result is white and therefor not visible. This addition will show modal boxes with text which is readable.